### PR TITLE
fixing issues with SES and config generation for non us-east-1 regions

### DIFF
--- a/dbt_config.tf
+++ b/dbt_config.tf
@@ -109,9 +109,9 @@ spec:
     run_logs_s3_bucket:
       value: ${local.s3_bucket_names.0}
     s3_endpoint_url:
-      default: https://s3.us-east-1.amazonaws.com
+      value: https://s3.${var.region}.amazonaws.com
     s3_region:
-      default: ${var.region}
+      value: ${var.region}
     saml_private_key: {}
     saml_public_cert: {}
     scaling_settings_type:
@@ -127,7 +127,7 @@ spec:
     smtp_enabled:
       value: "${var.enable_ses ? 1 : 0}"
     smtp_host:
-      value: ${var.enable_ses ? "email-smtp.us-east-1.amazonaws.com" : ""}
+      value: ${var.enable_ses ? "email-smtp.${var.region}.amazonaws.com" : ""}
     smtp_password:
       value: "${var.enable_ses ? aws_iam_access_key.ses_key.0.ses_smtp_password_v4 : ""}"
     smtp_port:
@@ -139,7 +139,7 @@ spec:
     storage_method:
       default: s3
     system_from_email_address:
-      value: "${var.enable_ses ? var.ses_email : ""}"
+      value: "${var.enable_ses ? "${var.ses_header} <${var.ses_email}>" : ""}"
 status: {}
 EOT
 }

--- a/examples/custom/main.tf
+++ b/examples/custom/main.tf
@@ -49,7 +49,8 @@ module "single_tenant_staging" {
 
   # enables creation of AWS SES resources for notifications
   enable_ses = true
-  ses_email  = "<dbt Support> support@example.com"
+  ses_email  = "support@example.com"
+  ses_header = "dbt Support"
 
   # pass a list of CIDR blocks to restrict traffic through load balancer
   load_balancer_source_ranges = ["100.68.0.0/18", "100.67.0.0/18"]

--- a/variables.tf
+++ b/variables.tf
@@ -51,6 +51,10 @@ variable "ses_email" {
   type    = string
   default = ""
 }
+variable "ses_header" {
+  type    = string
+  default = ""
+}
 variable "load_balancer_source_ranges" {
   type    = list(string)
   default = []


### PR DESCRIPTION
This PR fixes two issues:

1. The SES email identity was not always being validated and needed to be broken out from header
2. The script had 2 hard coded 'us-east-1' values (smtp host and s3/encryption region)