### PR TITLE
adding rds backup retention period to enable automated backups

### DIFF
--- a/examples/custom/main.tf
+++ b/examples/custom/main.tf
@@ -54,4 +54,7 @@ module "single_tenant_staging" {
 
   # pass a list of CIDR blocks to restrict traffic through load balancer
   load_balancer_source_ranges = ["100.68.0.0/18", "100.67.0.0/18"]
+
+  # by default the RDS backup retention is set to 7 days, setting to 0 will disable automated backups
+  rds_backup_retention_period = 0
 }

--- a/main.tf
+++ b/main.tf
@@ -77,7 +77,7 @@ resource "aws_db_instance" "backend_postgres" {
   skip_final_snapshot = true
   deletion_protection = true
 
-  backup_retention_period = var.rds_backup_retention_period
+  backup_retention_period  = var.rds_backup_retention_period
   delete_automated_backups = false
 
   lifecycle {

--- a/main.tf
+++ b/main.tf
@@ -77,6 +77,9 @@ resource "aws_db_instance" "backend_postgres" {
   skip_final_snapshot = true
   deletion_protection = true
 
+  backup_retention_period = var.rds_backup_retention_period
+  delete_automated_backups = false
+
   lifecycle {
     ignore_changes = [password]
   }

--- a/variables.tf
+++ b/variables.tf
@@ -131,6 +131,10 @@ variable "create_loadbalancer" {
   type    = bool
   default = true
 }
+variable "rds_backup_retention_period" {
+  type = number
+  default = 7
+}
 
 # locals
 data "aws_caller_identity" "current" {}

--- a/variables.tf
+++ b/variables.tf
@@ -132,7 +132,7 @@ variable "create_loadbalancer" {
   default = true
 }
 variable "rds_backup_retention_period" {
-  type = number
+  type    = number
   default = 7
 }
 


### PR DESCRIPTION
This PR updates the module to enable automated backups of RDS with a default retention of 7 days and to prevent deletion of snapshots upon database deletion.