### PR TITLE
updating dependencies for Terraform v13

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,4 +12,4 @@
 dbt_config.sh
 config.yaml
 
-.DS_STORE
+.DS_Store

--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,5 @@
 # generated dbt config files
 dbt_config.sh
 config.yaml
+
+.DS_STORE

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ Note that the `kubectl kots install` will prompt the user for a password for the
 
 | Name | Version |
 |------|---------|
-| terraform | >= 0.12.0 |
+| terraform | >= 0.13.0 |
 | aws | >= 2.0 |
 | local | >= 1.2 |
 | null | >= 2.0 |
@@ -83,7 +83,7 @@ Note that the `kubectl kots install` will prompt the user for a password for the
 |------|---------|
 | hashicorp/aws | >= 2.0 |
 | hashicorp/random | >= 3.0.0 |
-| hashicorp/kubernetes | >= 1.13.0 |
+| hashicorp/kubernetes | >= 1.9 |
 | hashicorp/tls | >= 3.0.0 |
 
 ## Module Dependencies
@@ -91,11 +91,11 @@ Note that the `kubectl kots install` will prompt the user for a password for the
 | Name | Version |
 |------|---------|
 | terraform-aws-modules/acm/aws | 2.12.0 |
-| terraform-aws-modules/s3-bucket/aws | 1.8.0 |
-| cloudposse/efs/aws | 0.16.0 |
+| terraform-aws-modules/s3-bucket/aws | 1.16.0 |
+| cloudposse/efs/aws | 0.22.0 |
 | terraform-aws-modules/eks/aws | 12.2.0 |
-| terraform-aws-modules/key-pair/aws | 0.4.0 |
-| cloudposse/kms-key/aws | 0.5.0 |
+| terraform-aws-modules/key-pair/aws | 0.5.0 |
+| cloudposse/kms-key/aws | 0.7.0 |
 
 ## Inputs
 

--- a/key_pair.tf
+++ b/key_pair.tf
@@ -18,7 +18,7 @@ resource "tls_private_key" "rsa_key_pair" {
 
 module "key_pair" {
   source  = "terraform-aws-modules/key-pair/aws"
-  version = "0.4.0"
+  version = "0.5.0"
 
   key_name   = "${var.namespace}-${var.environment}"
   public_key = tls_private_key.rsa_key_pair.public_key_openssh

--- a/kms.tf
+++ b/kms.tf
@@ -60,7 +60,7 @@ data "aws_iam_policy_document" "kms_key_policy" {
 
 module "kms_key" {
   source  = "cloudposse/kms-key/aws"
-  version = "0.5.0"
+  version = "0.7.0"
 
   namespace               = var.namespace
   environment             = var.environment

--- a/main.tf
+++ b/main.tf
@@ -30,7 +30,7 @@ resource "aws_security_group" "internal" {
 
 module "efs" {
   source  = "cloudposse/efs/aws"
-  version = "0.16.0"
+  version = "0.22.0"
 
   namespace   = var.namespace
   environment = var.environment

--- a/s3.tf
+++ b/s3.tf
@@ -43,7 +43,7 @@ resource "aws_s3_bucket_public_access_block" "block_public_access" {
 
 module "dbt_cloud_app_bucket" {
   source  = "terraform-aws-modules/s3-bucket/aws"
-  version = "1.8.0"
+  version = "1.16.0"
 
   bucket = "com.getdbt.cloud.${var.namespace}-${var.environment}.app"
   acl    = "private"
@@ -74,7 +74,7 @@ module "dbt_cloud_app_bucket" {
 
 module "dbt_cloud_per_branch_app_bucket" {
   source  = "terraform-aws-modules/s3-bucket/aws"
-  version = "1.8.0"
+  version = "1.16.0"
 
   bucket = "com.getdbt.cloud.${var.namespace}-${var.environment}.per-branch.app"
   acl    = "private"

--- a/versions.tf
+++ b/versions.tf
@@ -1,3 +1,3 @@
 terraform {
-  required_version = ">= 0.12.0"
+  required_version = ">= 0.13.0"
 }


### PR DESCRIPTION
This PR updates the necessary dependencies to use Terraform v13. This is a breaking change for existing modules and requires some manual state manipulation documented [here](https://www.notion.so/fishtownanalytics/Terraform-13-and-EKS-Module-Count-Upgrades-3331692eacaf40e984d2d77d540d0d45). The process described in the Notion page has been tested successfully twice in the staging environment.

This PR also adds `.DS_STORE` to the .gitignore file.