### PR TITLE
updating module to enable install into existing K8s cluster

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,17 +108,20 @@ Note that the `kubectl kots install` will prompt the user for a password for the
 | aws\_access\_key\_id | Admin Console Script - The AWS access key for an IAM identity with admin access that will be used for encryption. This is added to the config that is automatically uploaded to the KOTS admin console via the script. | `string` | `"<ENTER_AWS_ACCESS_KEY>"` | no |
 | aws\_secret\_access\_key | Admin Console Script - The AWS secret key for an IAM identity with admin access that will be used for encryption. This is added to the config that is automatically uploaded to the KOTS admin console via the script. | `string` | `"<ENTER_AWS_SECRET_KEY>"` | no |
 | cidr\_block | The CIDR block of the VPC that the infrastructure will be deployed in. | `string` | n/a | yes |
+| cluster\_name | Name of the cluster dbt Cloud will be installed into. Must be set if `create_eks_cluster` is set to `false`. | `string` | `""` | no |
 | create\_admin\_console\_script | If set to true will generate a script to automatically spin up the KOTS admin console with desired values and outputs from the module. The relevant variables below are suffixed with 'Admin Console Script' in their descriptions. These variables can also be left blank and manually entered into the script after applying if desired. | `bool` | `false` | no |
-| create\_efs\_provisioner | Set to false if creating a custom EFS provisioner storage class for the IDE. | `bool` | `true` | no |
-| create\_eks\_cluster | n/a | `bool` | `true` | no |
-| create\_loadbalancer | Set to false if creating a customer load balancer or other networking device to route traffic within the cluster. | `bool` | `true` | no |
+| create\_efs\_provisioner | Set to `false` if creating a custom EFS provisioner storage class for the IDE. | `bool` | `true` | no |
+| create\_eks\_cluster | Set to `false` if installing dbt Cloud into an existing EKS cluster. | `bool` | `true` | no |
+| create\_loadbalancer | Set to `false` if creating a customer load balancer or other networking device to route traffic within the cluster. | `bool` | `true` | no |
 | creation\_role\_arn | Admin Console Script - The ARN of the Terraform Creation Role. This is added to the script and used when setting the K8s context. | `string` | `"<ENTER_CREATION_ROLE_ARN>"` | no |
-| custom\_namespace | n/a | `string` | `""` | no |
-| datadog\_enabled | If set to true this will enable dbt Cloud to send metrics to Datadog. Note that this requires the installation of a Datadog Agent in the K8s cluster where dbt Cloud is deployed. | `bool` | `false` | no |
-| enable\_ses | If set to 'true' this will attempt to create an key pair for AWS Simple Email Service. If set to 'true' a valid from email address must be set in the 'ses\_email' variable. | `bool` | `false` | no |
+| custom\_internal\_security\_group\_id | The ID of an existing custom security group attached to an existing K8s cluster. This security group enables communication between the EKS worker nodes, RDS database, and EFS file system. It should be modeled after the `aws_security_group.internal` resource in this module. | `string` | `""` | no |
+| custom\_namespace | If set this variable will create a custom K8s namespace for dbt Cloud. If not set the created namespace defaults to `dbt-cloud-<namespace>-<environment>`. | `string` | `""` | no |
+| datadog\_enabled | If set to `true` this will enable dbt Cloud to send metrics to Datadog. Note that this requires the installation of a Datadog Agent in the K8s cluster where dbt Cloud is deployed. | `bool` | `false` | no |
+| enable\_ses | If set to `true` this will attempt to create an key pair for AWS Simple Email Service. If set to `true` a valid from email address must be set in the `ses_email` variable. | `bool` | `false` | no |
 | environment | The name of the environment for the deployment. For example: 'dev', 'prod', 'uat', 'standard', 'etc' | `string` | n/a | yes |
+| existing\_namespace | If set to `true`this will install dbt Cloud components into an existing namespace denoted by the `custom_namespace` field. This is not recommended as it is preferred to install dbt Cloud into a dedicated namespace. | `bool` | `false` | no |
 | hosted\_zone\_name | The root domain name of the hosted zone that will resolve to the dbt Cloud deployment. This should be a valid domain name that you own. | `string` | n/a | yes |
-| hostname\_affix | The affix of the URL, affixed to the 'hosted\_zone\_name' variable, that the dbt Cloud deployment will resolve to. If left blank the affix will default to the value of the 'environment' variable. | `string` | `""` | no |
+| hostname\_affix | The affix of the URL, affixed to the `hosted_zone_name` variable, that the dbt Cloud deployment will resolve to. If left blank the affix will default to the value of the `environment` variable. | `string` | `""` | no |
 | ide\_storage\_class | Admin Console Script - The EFS provisioner storage class name used for the IDE. Only change if creating a custom EFS provisioner. | `string` | `"aws-efs"` | no |
 | k8s\_node\_count | The number of Kubernetes nodes that will be created for the EKS worker group. Generally 2 nodes are recommended but it is recommended that you reach out to Fishtown Analytics to complete the capacity planning exercise prior to setting this. | `number` | n/a | yes |
 | k8s\_node\_size | The EC2 instance type of the Kubernetes nodes that will be created for the EKS worker group. It is recommended that you reach out to Fishtown Analytics to complete the capacity planning exercise prior to setting this. | `string` | n/a | yes |
@@ -136,9 +139,8 @@ Note that the `kubectl kots install` will prompt the user for a password for the
 | release\_channel | Admin Console Script - The license channel for customer deployment. This should be left unset unless instructed by Fishtown Analytics. | `string` | `""` | no |
 | scheduler\_memory | Admin Console Script - The amount of memory dedicated to the scheduler for dbt Cloud. This is added to the config that is automatically uploaded to the KOTS admin console via the script. This value should never be set to less than default. It is recommended that you reach out to Fishtown Analytics to complete the capacity planning exercise prior to modifying this. | `string` | `"1Gi"` | no |
 | ses\_email | A valid from email address to be used for AWS SES. This address will receive a validation email from AWS upon apply. | `string` | `""` | no |
-| ses\_header | The email header for notifications sent via SES. If left blank the header will simply display as the address set in the 'ses\_email' variable. | `string` | `""` | no |
+| ses\_header | The email header for notifications sent via SES. If left blank the header will simply display as the address set in the `ses_email` variable. | `string` | `""` | no |
 | superuser\_password | Admin Console Script - The superuser password for the dbt Cloud application. This is added to the config that is automatically uploaded to the KOTS admin console via the script. | `string` | `"<ENTER_SUPER_USER_PASSWORD>"` | no |
-| use\_custom\_namespace | n/a | `bool` | `false` | no |
 | vpc\_id | The ID of the VPC that the infrastructure will be deployed in. | `string` | n/a | yes |
 
 ## Outputs

--- a/api_gateway_loadbalancer.tf
+++ b/api_gateway_loadbalancer.tf
@@ -2,7 +2,7 @@ resource "kubernetes_service" "api_gateway_loadbalancer" {
   count = var.create_loadbalancer ? 1 : 0
   metadata {
     name      = "api-gateway-loadbalancer"
-    namespace = kubernetes_namespace.dbt_cloud.metadata.0.name
+    namespace = var.existing_namespace ? var.custom_namespace : kubernetes_namespace.dbt_cloud.0.metadata.0.name
     labels = {
       name = "api-gateway-loadbalancer"
     }

--- a/dbt_config.tf
+++ b/dbt_config.tf
@@ -19,10 +19,10 @@ resource "local_file" "script" {
 aws configure --profile dbt-cloud-${var.namespace}-${var.environment} set aws_access_key_id ${var.aws_access_key_id}
 aws configure --profile dbt-cloud-${var.namespace}-${var.environment} set aws_secret_access_key ${var.aws_secret_access_key}
 aws configure --profile dbt-cloud-${var.namespace}-${var.environment} set region ${var.region}
-aws eks update-kubeconfig --profile dbt-cloud-${var.namespace}-${var.environment} --name ${var.namespace}-${var.environment} --role-arn ${var.creation_role_arn}
-kubectl config set-context --current --namespace=dbt-cloud-${var.namespace}-${var.environment}
+aws eks update-kubeconfig --profile dbt-cloud-${var.namespace}-${var.environment} --name ${var.create_eks_cluster ? module.eks.0.cluster_id : var.cluster_name} --role-arn ${var.creation_role_arn}
+kubectl config set-context --current --namespace=${var.existing_namespace ? var.custom_namespace : kubernetes_namespace.dbt_cloud.0.metadata.0.name}
 curl https://kots.io/install | bash
-kubectl kots install dbt-cloud-v1${var.release_channel} --namespace dbt-cloud-${var.namespace}-${var.environment} --shared-password ${var.admin_console_password} --config-values ${local_file.config.0.filename}
+kubectl kots install dbt-cloud-v1${var.release_channel} --namespace ${var.existing_namespace ? var.custom_namespace : kubernetes_namespace.dbt_cloud.0.metadata.0.name} --shared-password ${var.admin_console_password} --config-values ${local_file.config.0.filename}
 EOT
 }
 

--- a/efs_provisioner.tf
+++ b/efs_provisioner.tf
@@ -2,7 +2,7 @@ resource "kubernetes_service_account" "efs_provisioner" {
   count = var.create_efs_provisioner ? 1 : 0
   metadata {
     name      = "efs-provisioner"
-    namespace = kubernetes_namespace.dbt_cloud.metadata.0.name
+    namespace = var.existing_namespace ? var.custom_namespace : kubernetes_namespace.dbt_cloud.0.metadata.0.name
   }
 
   automount_service_account_token = true
@@ -58,7 +58,7 @@ resource "kubernetes_cluster_role_binding" "run_efs_provisioner" {
   subject {
     kind      = "ServiceAccount"
     name      = "efs-provisioner"
-    namespace = kubernetes_namespace.dbt_cloud.metadata.0.name
+    namespace = var.existing_namespace ? var.custom_namespace : kubernetes_namespace.dbt_cloud.0.metadata.0.name
   }
 }
 
@@ -66,7 +66,7 @@ resource "kubernetes_role" "leader_locking_efs_provisioner" {
   count = var.create_efs_provisioner ? 1 : 0
   metadata {
     name      = "leader-locking-efs-provisioner"
-    namespace = kubernetes_namespace.dbt_cloud.metadata.0.name
+    namespace = var.existing_namespace ? var.custom_namespace : kubernetes_namespace.dbt_cloud.0.metadata.0.name
   }
   rule {
     api_groups = [""]
@@ -79,7 +79,7 @@ resource "kubernetes_role_binding" "leader_locking_efs_provisioner" {
   count = var.create_efs_provisioner ? 1 : 0
   metadata {
     name      = "leader-locking-efs-provisioner"
-    namespace = kubernetes_namespace.dbt_cloud.metadata.0.name
+    namespace = var.existing_namespace ? var.custom_namespace : kubernetes_namespace.dbt_cloud.0.metadata.0.name
   }
   role_ref {
     api_group = "rbac.authorization.k8s.io"
@@ -89,7 +89,7 @@ resource "kubernetes_role_binding" "leader_locking_efs_provisioner" {
   subject {
     kind      = "ServiceAccount"
     name      = "efs-provisioner"
-    namespace = kubernetes_namespace.dbt_cloud.metadata.0.name
+    namespace = var.existing_namespace ? var.custom_namespace : kubernetes_namespace.dbt_cloud.0.metadata.0.name
   }
   subject {
     kind      = "Group"
@@ -102,7 +102,7 @@ resource "kubernetes_config_map" "efs_provisioner" {
   count = var.create_efs_provisioner ? 1 : 0
   metadata {
     name      = "efs-provisioner"
-    namespace = kubernetes_namespace.dbt_cloud.metadata.0.name
+    namespace = var.existing_namespace ? var.custom_namespace : kubernetes_namespace.dbt_cloud.0.metadata.0.name
   }
 
   data = {
@@ -117,7 +117,7 @@ resource "kubernetes_deployment" "efs_provisioner" {
   count = var.create_efs_provisioner ? 1 : 0
   metadata {
     name      = "efs-provisioner"
-    namespace = kubernetes_namespace.dbt_cloud.metadata.0.name
+    namespace = var.existing_namespace ? var.custom_namespace : kubernetes_namespace.dbt_cloud.0.metadata.0.name
     labels = {
       name = "efs-provisioner"
     }
@@ -222,7 +222,7 @@ resource "kubernetes_persistent_volume_claim" "efs" {
     annotations = {
       "volume.beta.kubernetes.io/storage-class" = kubernetes_storage_class.aws_efs.0.metadata.0.name
     }
-    namespace = kubernetes_namespace.dbt_cloud.metadata.0.name
+    namespace = var.existing_namespace ? var.custom_namespace : kubernetes_namespace.dbt_cloud.0.metadata.0.name
   }
   spec {
     access_modes = ["ReadWriteMany"]

--- a/eks_cluster_config.tf
+++ b/eks_cluster_config.tf
@@ -1,12 +1,13 @@
 data "aws_eks_cluster" "cluster" {
-  name = module.eks.cluster_id
+  name = var.create_eks_cluster ? module.eks.0.cluster_id : var.cluster_name
 }
 
 data "aws_eks_cluster_auth" "cluster" {
-  name = module.eks.cluster_id
+  name = var.create_eks_cluster ? module.eks.0.cluster_id : var.cluster_name
 }
 
 data "aws_ami" "eks_worker_ami_1_16" {
+  count = var.create_eks_cluster ? 1 : 0
   filter {
     name   = "name"
     values = ["ubuntu-eks/k8s_1.16/images/*"]
@@ -97,11 +98,13 @@ USERDATA
 }
 
 resource "aws_iam_policy" "nodes_kubernetes" {
+  count  = var.create_eks_cluster ? 1 : 0
   name   = "nodes.kubernetes.${var.namespace}-${var.environment}"
-  policy = data.aws_iam_policy_document.nodes_kubernetes.json
+  policy = data.aws_iam_policy_document.nodes_kubernetes.0.json
 }
 
 data "aws_iam_policy_document" "nodes_kubernetes" {
+  count = var.create_eks_cluster ? 1 : 0
   statement {
     actions = [
       "ec2:Describe*",

--- a/examples/existing_k8s/main.tf
+++ b/examples/existing_k8s/main.tf
@@ -6,7 +6,16 @@ provider "aws" {
   }
 }
 
-module "single_tenant_staging" {
+# retrieve the subnet IDs corresponding to the private IP CIDR blocks
+data "aws_subnet_ids" "private" {
+  vpc_id = var.vpc_id
+  filter {
+    name   = "cidr-block"
+    values = values(var.subnets.private)
+  }
+}
+
+module "single_tenant_existing" {
 
   source = "../../"
 
@@ -17,9 +26,9 @@ module "single_tenant_staging" {
   region                  = var.region
   postgres_instance_class = var.postgres_instance_class
   postgres_storage        = var.postgres_storage
-  cidr_block              = module.vpc.vpc_cidr_block
-  vpc_id                  = module.vpc.vpc_id
-  private_subnets         = module.vpc.private_subnets
+  cidr_block              = var.cidr_block
+  vpc_id                  = var.vpc_id
+  private_subnets         = data.aws_subnet_ids.private.ids # The private subnet IDs from the VPC
   key_admins              = var.key_admins
   hosted_zone_name        = "singletenant.getdbt.com"
   creation_role_arn       = var.creation_role_arn
@@ -33,26 +42,18 @@ module "single_tenant_staging" {
   superuser_password          = "<ENTER_SUPERUSER_PASSWORD>"
   admin_console_password      = "<ENTER_ADMIN_CONSOLE_PASSWORD>"
 
-  # allows user to set custom k8s user data
-  additional_k8s_user_data = <<-EOT
-  # Custom user data
-  EOT
-
-  # disables creation of efs provisioner if a custom provisioner is desired
-  create_efs_provisioner = false
-  ide_storage_class      = "custom-storage-class"
-
-  # disables creation of load balancer if a custom dns configuration is desired
-  create_loadbalancer = false
-
   # enables creation of AWS SES resources for notifications
   enable_ses = true
   ses_email  = "support@example.com"
   ses_header = "dbt Cloud Support"
 
-  # pass a list of CIDR blocks to restrict traffic through load balancer
-  load_balancer_source_ranges = ["100.68.0.0/18", "100.67.0.0/18"]
+  # set to false to bypass EKS cluster creation and install into existing cluster
+  create_eks_cluster = false
+  custom_namespace   = "<ENTER_CUSTOM_NAMESPACE>"
+  cluster_name       = "<ENTER_EXISTING_CLUSTER_NAME>"
 
-  # by default the RDS backup retention is set to 7 days, setting to 0 will disable automated backups
-  rds_backup_retention_period = 0
+  # set to true to install in existing namespace
+  existing_namespace = true
+
+  custom_internal_security_group_id = "<ENTER_CUSTOM_CLUSTER_SECURITY_GROUP_ID>"
 }

--- a/examples/existing_k8s/variables.tf
+++ b/examples/existing_k8s/variables.tf
@@ -1,0 +1,53 @@
+variable "namespace" {
+  default = "singletenant"
+}
+
+variable "environment" {
+  default = "existing"
+}
+
+variable "region" {
+  default = "us-east-1"
+}
+
+variable "creation_role_arn" {
+  default = "<ENTER_CREATION_ROLE_ARN>"
+}
+
+variable "postgres_instance_class" {
+  default = "db.t3.micro"
+}
+
+variable "postgres_storage" {
+  default = "100"
+}
+
+variable "key_admins" {
+  default = [
+    "bootstrapping",
+  ]
+}
+
+variable "vpc_id" {
+  default = "<ENTER_VPC_ID>" # enter VPC ID where existing K8s cluster lives
+}
+
+variable "cidr_block" {
+  default = "10.191.0.0/16"
+  type    = string
+}
+
+variable "subnets" {
+  default = {
+    private = {
+      us-east-1a = "10.191.0.0/20"
+      us-east-1b = "10.191.16.0/20"
+      us-east-1c = "10.191.32.0/20"
+    }
+    public = {
+      us-east-1a = "10.191.64.0/20"
+      us-east-1b = "10.191.80.0/20"
+      us-east-1c = "10.191.96.0/20"
+    }
+  }
+}

--- a/variables.tf
+++ b/variables.tf
@@ -61,7 +61,7 @@ variable "key_users" {
 variable "enable_ses" {
   type        = bool
   default     = false
-  description = "If set to 'true' this will attempt to create an key pair for AWS Simple Email Service. If set to 'true' a valid from email address must be set in the 'ses_email' variable."
+  description = "If set to `true` this will attempt to create an key pair for AWS Simple Email Service. If set to `true` a valid from email address must be set in the `ses_email` variable."
 }
 variable "ses_email" {
   type        = string
@@ -71,7 +71,7 @@ variable "ses_email" {
 variable "ses_header" {
   type        = string
   default     = ""
-  description = "The email header for notifications sent via SES. If left blank the header will simply display as the address set in the 'ses_email' variable."
+  description = "The email header for notifications sent via SES. If left blank the header will simply display as the address set in the `ses_email` variable."
 }
 variable "load_balancer_source_ranges" {
   type        = list(string)
@@ -111,12 +111,12 @@ variable "superuser_password" {
 variable "datadog_enabled" {
   type        = bool
   default     = false
-  description = "If set to true this will enable dbt Cloud to send metrics to Datadog. Note that this requires the installation of a Datadog Agent in the K8s cluster where dbt Cloud is deployed."
+  description = "If set to `true` this will enable dbt Cloud to send metrics to Datadog. Note that this requires the installation of a Datadog Agent in the K8s cluster where dbt Cloud is deployed."
 }
 variable "hostname_affix" {
   type        = string
   default     = ""
-  description = "The affix of the URL, affixed to the 'hosted_zone_name' variable, that the dbt Cloud deployment will resolve to. If left blank the affix will default to the value of the 'environment' variable."
+  description = "The affix of the URL, affixed to the `hosted_zone_name` variable, that the dbt Cloud deployment will resolve to. If left blank the affix will default to the value of the `environment` variable."
 }
 variable "release_channel" {
   type        = string
@@ -151,7 +151,7 @@ variable "additional_k8s_user_data" {
 variable "create_efs_provisioner" {
   type        = bool
   default     = true
-  description = "Set to false if creating a custom EFS provisioner storage class for the IDE."
+  description = "Set to `false` if creating a custom EFS provisioner storage class for the IDE."
 }
 variable "ide_storage_class" {
   type        = string
@@ -161,12 +161,37 @@ variable "ide_storage_class" {
 variable "create_loadbalancer" {
   type        = bool
   default     = true
-  description = "Set to false if creating a customer load balancer or other networking device to route traffic within the cluster."
+  description = "Set to `false` if creating a customer load balancer or other networking device to route traffic within the cluster."
 }
 variable "rds_backup_retention_period" {
   type        = number
   default     = 7
   description = "The number of days for RDS to create automated snapshot backups. Set to a max of 35 or set to 0 to disable automated backups."
+}
+variable "create_eks_cluster" {
+  type        = bool
+  default     = true
+  description = "Set to `false` if installing dbt Cloud into an existing EKS cluster."
+}
+variable "custom_namespace" {
+  type        = string
+  default     = ""
+  description = "If set this variable will create a custom K8s namespace for dbt Cloud. If not set the created namespace defaults to `dbt-cloud-<namespace>-<environment>`."
+}
+variable "cluster_name" {
+  type        = string
+  default     = ""
+  description = "Name of the cluster dbt Cloud will be installed into. Must be set if `create_eks_cluster` is set to `false`."
+}
+variable "existing_namespace" {
+  type        = bool
+  default     = false
+  description = "If set to `true`this will install dbt Cloud components into an existing namespace denoted by the `custom_namespace` field. This is not recommended as it is preferred to install dbt Cloud into a dedicated namespace."
+}
+variable "custom_internal_security_group_id" {
+  type        = string
+  default     = ""
+  description = "The ID of an existing custom security group attached to an existing K8s cluster. This security group enables communication between the EKS worker nodes, RDS database, and EFS file system. It should be modeled after the `aws_security_group.internal` resource in this module. "
 }
 
 # locals


### PR DESCRIPTION
This PR adds the ability to install into an existing EKS cluster to the module. Upgrading to this version of the module requires manually manipulating the state as described in the [Upgrading to EKS](https://www.notion.so/fishtownanalytics/Terraform-13-and-EKS-Module-Count-Upgrades-3331692eacaf40e984d2d77d540d0d45) section of the Notion page. As this is technically a breaking change, the module version will be incremented to 0.3.0 in the TF registry.

The following deployment scenarios were successfully tested. 

- Deploying into an existing EKS cluster with a custom namespace
- Deploying into an existing EKS cluster with an existing namespace
- Upgrading an existing deployment to this module version