### PR TITLE
adding flag to enable multi az for RDS

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,7 @@ Note that the `kubectl kots install` will prompt the user for a password for the
 | postgres\_storage | The amount of storage allocated to the RDS database in GB. Generally 100 GB is standard but it is recommended that you reach out to Fishtown Analytics to complete the capacity planning exercise prior to setting this. | `string` | n/a | yes |
 | private\_subnets | The list of private subnets for the VPC that the infrastructure will be deployed in. | `list(string)` | n/a | yes |
 | rds\_backup\_retention\_period | The number of days for RDS to create automated snapshot backups. Set to a max of 35 or set to 0 to disable automated backups. | `number` | `7` | no |
+| rds\_multi\_az | Set to `false` to disable Multi-AZ deployment for Postgres RDS database. | `bool` | `true` | no |
 | rds\_password | Password for RDS database. It is highly recommended that a secure password be generated and stored in a vault. | `string` | n/a | yes |
 | region | The AWS region where the infrastructure will be deployed. For example 'us-east-1'. | `string` | n/a | yes |
 | release\_channel | Admin Console Script - The license channel for customer deployment. This should be left unset unless instructed by Fishtown Analytics. | `string` | `""` | no |

--- a/main.tf
+++ b/main.tf
@@ -71,6 +71,7 @@ resource "aws_db_instance" "backend_postgres" {
   username               = "${var.namespace}${var.environment}"
   password               = var.rds_password
   storage_encrypted      = true
+  multi_az               = var.rds_multi_az
   kms_key_id             = module.kms_key.key_arn
   db_subnet_group_name   = aws_db_subnet_group.private.name
   vpc_security_group_ids = [var.custom_internal_security_group_id == "" ? aws_security_group.internal.0.id : var.custom_internal_security_group_id]

--- a/variables.tf
+++ b/variables.tf
@@ -203,6 +203,11 @@ variable "alias_domain_name" {
   default     = ""
   description = "A valid alias domain for corresponding Route53 record. Must be set if `create_alias_record` is set to `true`."
 }
+variable "rds_multi_az" {
+  type        = bool
+  default     = true
+  description = "Set to `false` to disable Multi-AZ deployment for Postgres RDS database."
+}
 
 # locals
 data "aws_caller_identity" "current" {}


### PR DESCRIPTION
This PR adds a flag to enable Multi-AZ for the Postgres RDS db in AWS single tenant. The flag is set to true by default with an option to disable if desired. This has been tested successfully in the staging environment.

[tf plan - multi-az.txt](https://github.com/fishtown-analytics/terraform-aws-dbt-cloud-single-tenant/files/5705946/tf.plan.-.multi-az.txt)
