### PR TITLE
adding helm resources for kube-cleanup-operator and reloader

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,8 @@ Note that the `kubectl kots install` will prompt the user for a password for the
 | custom\_internal\_security\_group\_id | The ID of an existing custom security group attached to an existing K8s cluster. This security group enables communication between the EKS worker nodes, RDS database, and EFS file system. It should be modeled after the `aws_security_group.internal` resource in this module. | `string` | `""` | no |
 | custom\_namespace | If set this variable will create a custom K8s namespace for dbt Cloud. If not set the created namespace defaults to `dbt-cloud-<namespace>-<environment>`. | `string` | `""` | no |
 | datadog\_enabled | If set to `true` this will enable dbt Cloud to send metrics to Datadog. Note that this requires the installation of a Datadog Agent in the K8s cluster where dbt Cloud is deployed. | `bool` | `false` | no |
+| enable\_kube\_cleanup\_operator | Set to `false` to disable kube-cleanup-operator deployment. | `bool` | `true` | no |
+| enable\_reloader | Set to `false` to disable reloader. | `bool` | `true` | no |
 | enable\_ses | If set to `true` this will attempt to create an key pair for AWS Simple Email Service. If set to `true` a valid from email address must be set in the `ses_email` variable. | `bool` | `false` | no |
 | environment | The name of the environment for the deployment. For example: 'dev', 'prod', 'uat', 'standard', 'etc' | `string` | n/a | yes |
 | existing\_namespace | If set to `true`this will install dbt Cloud components into an existing namespace denoted by the `custom_namespace` field. This is not recommended as it is preferred to install dbt Cloud into a dedicated namespace. | `bool` | `false` | no |
@@ -150,8 +152,10 @@ Note that the `kubectl kots install` will prompt the user for a password for the
 
 | Name | Description |
 |------|-------------|
+| app\_memory\_bytes | The aggregate memory allocated to all app pods in the cluster in bytes. Used for setting monitoring thresholds. |
 | database\_hostname | The hostname (address) of the RDS database generated. This is required to be entered manually in the configuration console if not using the generated script. |
 | efs\_dns\_name | The DNS name generated for the EFS instance. This may be required if creating a custom EFS provisioner. |
 | efs\_id | The ID generated for the EFS instance. This may be required if creating a custom EFS provisioner. |
 | instance\_url | The URL where the dbt Cloud instance can be accessed. |
 | kms\_key\_arn | The ARN of the KMS key created. May be manually entered for encryption in the configuration console if not using the generated script. |
+| scheduler\_memory\_bytes | The aggregate memory allocated to all scheduler pods in the cluster in bytes. Used for setting monitoring thresholds. |

--- a/README.md
+++ b/README.md
@@ -152,10 +152,8 @@ Note that the `kubectl kots install` will prompt the user for a password for the
 
 | Name | Description |
 |------|-------------|
-| app\_memory\_bytes | The aggregate memory allocated to all app pods in the cluster in bytes. Used for setting monitoring thresholds. |
 | database\_hostname | The hostname (address) of the RDS database generated. This is required to be entered manually in the configuration console if not using the generated script. |
 | efs\_dns\_name | The DNS name generated for the EFS instance. This may be required if creating a custom EFS provisioner. |
 | efs\_id | The ID generated for the EFS instance. This may be required if creating a custom EFS provisioner. |
 | instance\_url | The URL where the dbt Cloud instance can be accessed. |
 | kms\_key\_arn | The ARN of the KMS key created. May be manually entered for encryption in the configuration console if not using the generated script. |
-| scheduler\_memory\_bytes | The aggregate memory allocated to all three containers in the scheduler pod in bytes. Used for setting monitoring thresholds. |

--- a/README.md
+++ b/README.md
@@ -158,4 +158,4 @@ Note that the `kubectl kots install` will prompt the user for a password for the
 | efs\_id | The ID generated for the EFS instance. This may be required if creating a custom EFS provisioner. |
 | instance\_url | The URL where the dbt Cloud instance can be accessed. |
 | kms\_key\_arn | The ARN of the KMS key created. May be manually entered for encryption in the configuration console if not using the generated script. |
-| scheduler\_memory\_bytes | The aggregate memory allocated to all scheduler pods in the cluster in bytes. Used for setting monitoring thresholds. |
+| scheduler\_memory\_bytes | The aggregate memory allocated to all three containers in the scheduler pod in bytes. Used for setting monitoring thresholds. |

--- a/helm.tf
+++ b/helm.tf
@@ -1,0 +1,58 @@
+provider "helm" {
+  kubernetes {
+    host                   = data.aws_eks_cluster.cluster.endpoint
+    cluster_ca_certificate = base64decode(data.aws_eks_cluster.cluster.certificate_authority.0.data)
+    token                  = data.aws_eks_cluster_auth.cluster.token
+  }
+}
+
+resource "helm_release" "kube_cleanup_operator" {
+  count = var.enable_kube_cleanup_operator ? 1 : 0
+
+  name       = "kube-cleanup-operator"
+  repository = "https://charts.lwolf.org"
+  chart      = "kube-cleanup-operator"
+  version    = "1.0.1"
+
+  namespace = var.existing_namespace ? var.custom_namespace : kubernetes_namespace.dbt_cloud.0.metadata.0.name
+
+  values = [
+    <<-EOT
+    resources:
+      limits:
+        cpu: 250m
+        memory: 500Mi
+      requests:
+        cpu: 250m
+        memory: 250Mi
+
+    args:
+      - --namespace=${var.existing_namespace ? var.custom_namespace : kubernetes_namespace.dbt_cloud.0.metadata.0.name}
+      - --dry-run=false
+      - --delete-successful-after=1h
+      - --delete-failed-after=1h
+      - --delete-pending-pods-after=24h
+      - --ignore-owned-by-cronjobs=true
+      - --legacy-mode=false
+
+    metrics:
+      enabled: false
+    EOT
+  ]
+}
+
+resource "helm_release" "reloader" {
+  count = var.enable_reloader ? 1 : 0
+
+  name       = "reloader"
+  repository = "https://stakater.github.io/stakater-charts"
+  chart      = "reloader"
+  version    = "0.0.75"
+
+  namespace = var.existing_namespace ? var.custom_namespace : kubernetes_namespace.dbt_cloud.0.metadata.0.name
+
+  set {
+    name  = "reloader.logFormat"
+    value = "json"
+  }
+}

--- a/outputs.tf
+++ b/outputs.tf
@@ -29,6 +29,6 @@ output "app_memory_bytes" {
 }
 
 output "scheduler_memory_bytes" {
-  value       = replace(var.scheduler_memory, "/[0-9]/", "") == "Gi" ? tonumber(replace(var.scheduler_memory, "/[A-Za-z]/", "")) * 1074000000 : tonumber(replace(var.scheduler_memory, "/[A-Za-z]/", "")) * 1049000
-  description = "The aggregate memory allocated to all scheduler pods in the cluster in bytes. Used for setting monitoring thresholds."
+  value       = replace(var.scheduler_memory, "/[0-9]/", "") == "Gi" ? tonumber(replace(var.scheduler_memory, "/[A-Za-z]/", "")) * 1074000000 * 3 : tonumber(replace(var.scheduler_memory, "/[A-Za-z]/", "")) * 1049000 * 3
+  description = "The aggregate memory allocated to all three containers in the scheduler pod in bytes. Used for setting monitoring thresholds."
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -22,13 +22,3 @@ output "kms_key_arn" {
   value       = module.kms_key.key_arn
   description = "The ARN of the KMS key created. May be manually entered for encryption in the configuration console if not using the generated script."
 }
-
-output "app_memory_bytes" {
-  value       = replace(var.app_memory, "/[0-9]/", "") == "Gi" ? tonumber(replace(var.app_memory, "/[A-Za-z]/", "")) * var.app_replicas * 1074000000 : tonumber(replace(var.app_memory, "/[A-Za-z]/", "")) * var.app_replicas * 1049000
-  description = "The aggregate memory allocated to all app pods in the cluster in bytes. Used for setting monitoring thresholds."
-}
-
-output "scheduler_memory_bytes" {
-  value       = replace(var.scheduler_memory, "/[0-9]/", "") == "Gi" ? tonumber(replace(var.scheduler_memory, "/[A-Za-z]/", "")) * 1074000000 * 3 : tonumber(replace(var.scheduler_memory, "/[A-Za-z]/", "")) * 1049000 * 3
-  description = "The aggregate memory allocated to all three containers in the scheduler pod in bytes. Used for setting monitoring thresholds."
-}

--- a/outputs.tf
+++ b/outputs.tf
@@ -22,3 +22,13 @@ output "kms_key_arn" {
   value       = module.kms_key.key_arn
   description = "The ARN of the KMS key created. May be manually entered for encryption in the configuration console if not using the generated script."
 }
+
+output "app_memory_bytes" {
+  value       = replace(var.app_memory, "/[0-9]/", "") == "Gi" ? tonumber(replace(var.app_memory, "/[A-Za-z]/", "")) * var.app_replicas * 1074000000 : tonumber(replace(var.app_memory, "/[A-Za-z]/", "")) * var.app_replicas * 1049000
+  description = "The aggregate memory allocated to all app pods in the cluster in bytes. Used for setting monitoring thresholds."
+}
+
+output "scheduler_memory_bytes" {
+  value       = replace(var.scheduler_memory, "/[0-9]/", "") == "Gi" ? tonumber(replace(var.scheduler_memory, "/[A-Za-z]/", "")) * 1074000000 : tonumber(replace(var.scheduler_memory, "/[A-Za-z]/", "")) * 1049000
+  description = "The aggregate memory allocated to all scheduler pods in the cluster in bytes. Used for setting monitoring thresholds."
+}

--- a/variables.tf
+++ b/variables.tf
@@ -208,6 +208,16 @@ variable "rds_multi_az" {
   default     = true
   description = "Set to `false` to disable Multi-AZ deployment for Postgres RDS database."
 }
+variable "enable_kube_cleanup_operator" {
+  type        = bool
+  default     = true
+  description = "Set to `false` to disable kube-cleanup-operator deployment."
+}
+variable "enable_reloader" {
+  type        = bool
+  default     = true
+  description = "Set to `false` to disable reloader."
+}
 
 # locals
 data "aws_caller_identity" "current" {}


### PR DESCRIPTION
This PR adds helm resources to deploy the kube-cleanup-operator and the reloader for single tenant. Both of these resources have been successfully tested locally in the staging environment.

The terraform plan is below:


```
Terraform will perform the following actions:

  # module.single_tenant_staging.helm_release.kube_cleanup_operator[0] will be created
  + resource "helm_release" "kube_cleanup_operator" {
      + atomic                     = false
      + chart                      = "kube-cleanup-operator"
      + cleanup_on_fail            = false
      + create_namespace           = false
      + dependency_update          = false
      + disable_crd_hooks          = false
      + disable_openapi_validation = false
      + disable_webhooks           = false
      + force_update               = false
      + id                         = (known after apply)
      + lint                       = false
      + max_history                = 0
      + metadata                   = (known after apply)
      + name                       = "kube-cleanup-operator"
      + namespace                  = "dbt-cloud-singletenant-standard"
      + recreate_pods              = false
      + render_subchart_notes      = true
      + replace                    = false
      + repository                 = "https://charts.lwolf.org"
      + reset_values               = false
      + reuse_values               = false
      + skip_crds                  = false
      + status                     = "deployed"
      + timeout                    = 300
      + values                     = [
          + <<~EOT
                resources:
                  limits:
                    cpu: 250m
                    memory: 500Mi
                  requests:
                    cpu: 250m
                    memory: 250Mi
                
                args:
                  - --namespace=dbt-cloud-singletenant-standard
                  - --dry-run=false
                  - --delete-successful-after=1h
                  - --delete-failed-after=1h
                  - --delete-pending-pods-after=24h
                  - --ignore-owned-by-cronjobs=true
                  - --legacy-mode=false
                
                metrics:
                  enabled: false
            EOT,
        ]
      + verify                     = false
      + version                    = "1.0.1"
      + wait                       = true
    }

  # module.single_tenant_staging.helm_release.reloader[0] will be created
  + resource "helm_release" "reloader" {
      + atomic                     = false
      + chart                      = "reloader"
      + cleanup_on_fail            = false
      + create_namespace           = false
      + dependency_update          = false
      + disable_crd_hooks          = false
      + disable_openapi_validation = false
      + disable_webhooks           = false
      + force_update               = false
      + id                         = (known after apply)
      + lint                       = false
      + max_history                = 0
      + metadata                   = (known after apply)
      + name                       = "reloader"
      + namespace                  = "dbt-cloud-singletenant-standard"
      + recreate_pods              = false
      + render_subchart_notes      = true
      + replace                    = false
      + repository                 = "https://stakater.github.io/stakater-charts"
      + reset_values               = false
      + reuse_values               = false
      + skip_crds                  = false
      + status                     = "deployed"
      + timeout                    = 300
      + verify                     = false
      + version                    = "v0.0.75"
      + wait                       = true

      + set {
          + name  = "reloader.logFormat"
          + value = "json"
        }
    }

Plan: 2 to add, 0 to change, 0 to destroy.
```