### PR TITLE
adding helm chart resource to deploy datadog agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ Note that the `kubectl kots install` will prompt the user for a password for the
 | custom\_namespace | If set this variable will create a custom K8s namespace for dbt Cloud. If not set the created namespace defaults to `dbt-cloud-<namespace>-<environment>`. | `string` | `""` | no |
 | datadog\_agent\_memory\_limit | The resource memory limit of the Datadog agent. | `string` | `"512Mi"` | no |
 | datadog\_agent\_memory\_request | The resource memory request of the Datadog agent. | `string` | `"256Mi"` | no |
-| datadog\_api\_key | Must be set if `enable_datadog` is set to `true` | `string` | `""` | no |
+| datadog\_api\_key | If `enable_datadog` is set to `true`, this variable must be set to valid API key of the destination Datadog account. | `string` | `""` | no |
 | enable\_datadog | If set to `true` this will enable dbt Cloud to send metrics to Datadog. Note that this requires the installation of a Datadog Agent in the K8s cluster where dbt Cloud is deployed. | `bool` | `false` | no |
 | enable\_datadog\_apm | Set to `true` to enable APM (tracer agent) for Datadog. Will only take effect if `enable_datadog_agent` is also set to `true`. | `bool` | `false` | no |
 | enable\_datadog\_cluster\_agent | Set to `true` to enable cluster agent for Datadog. Will only take effect if `enable_datadog_agent` is also set to `true`. | `bool` | `false` | no |

--- a/README.md
+++ b/README.md
@@ -118,7 +118,14 @@ Note that the `kubectl kots install` will prompt the user for a password for the
 | creation\_role\_arn | Admin Console Script - The ARN of the Terraform Creation Role. This is added to the script and used when setting the K8s context. | `string` | `"<ENTER_CREATION_ROLE_ARN>"` | no |
 | custom\_internal\_security\_group\_id | The ID of an existing custom security group attached to an existing K8s cluster. This security group enables communication between the EKS worker nodes, RDS database, and EFS file system. It should be modeled after the `aws_security_group.internal` resource in this module. | `string` | `""` | no |
 | custom\_namespace | If set this variable will create a custom K8s namespace for dbt Cloud. If not set the created namespace defaults to `dbt-cloud-<namespace>-<environment>`. | `string` | `""` | no |
-| datadog\_enabled | If set to `true` this will enable dbt Cloud to send metrics to Datadog. Note that this requires the installation of a Datadog Agent in the K8s cluster where dbt Cloud is deployed. | `bool` | `false` | no |
+| datadog\_agent\_memory\_limit | The resource memory limit of the Datadog agent. | `string` | `"512Mi"` | no |
+| datadog\_agent\_memory\_request | The resource memory request of the Datadog agent. | `string` | `"256Mi"` | no |
+| datadog\_api\_key | Must be set if `enable_datadog` is set to `true` | `string` | `""` | no |
+| enable\_datadog | If set to `true` this will enable dbt Cloud to send metrics to Datadog. Note that this requires the installation of a Datadog Agent in the K8s cluster where dbt Cloud is deployed. | `bool` | `false` | no |
+| enable\_datadog\_apm | Set to `true` to enable APM (tracer agent) for Datadog. Will only take effect if `enable_datadog_agent` is also set to `true`. | `bool` | `false` | no |
+| enable\_datadog\_cluster\_agent | Set to `true` to enable cluster agent for Datadog. Will only take effect if `enable_datadog_agent` is also set to `true`. | `bool` | `false` | no |
+| enable\_datadog\_kube\_state\_metrics | Set to `true` to enable kube state metrics for Datadog. Will only take effect if `enable_datadog_agent` is also set to `true`. | `bool` | `false` | no |
+| enable\_datadog\_process\_agent | Set to `true` to enable process agent for Datadog. Will only take effect if `enable_datadog_agent` is also set to `true`. | `bool` | `false` | no |
 | enable\_kube\_cleanup\_operator | Set to `false` to disable kube-cleanup-operator deployment. | `bool` | `true` | no |
 | enable\_reloader | Set to `false` to disable reloader. | `bool` | `true` | no |
 | enable\_ses | If set to `true` this will attempt to create an key pair for AWS Simple Email Service. If set to `true` a valid from email address must be set in the `ses_email` variable. | `bool` | `false` | no |

--- a/dbt_config.tf
+++ b/dbt_config.tf
@@ -65,7 +65,7 @@ spec:
     database_user:
       value: "${var.namespace}${var.environment}"
     datadog_enabled:
-      value: "${var.datadog_enabled == true ? 1 : 0}"
+      value: "${var.enable_datadog == true ? 1 : 0}"
     db_type:
       default: external
       value: external

--- a/helm.tf
+++ b/helm.tf
@@ -71,11 +71,25 @@ resource "helm_release" "datadog" {
     value = var.datadog_api_key
   }
 
+  # optional add ons
   set {
     name  = "datadog.apm.enabled"
     value = var.enable_datadog_apm
   }
+  set {
+    name  = "clusterAgent.enabled"
+    value = var.enable_datadog_cluster_agent
+  }
+  set {
+    name  = "datadog.kubeStateMetricsEnabled"
+    value = var.enable_datadog_kube_state_metrics
+  }
+  set {
+    name  = "datadog.processAgent.enabled"
+    value = var.enable_datadog_process_agent
+  }
 
+  # required settings
   set {
     name  = "datadog.logs.enabled"
     value = true
@@ -92,15 +106,19 @@ resource "helm_release" "datadog" {
     name  = "datadog.collectEvents"
     value = true
   }
+  set {
+    name  = "datadog.dogstatsd.useHostPort"
+    value = true
+  }
 
   # agent memory
   set {
     name  = "agents.containers.agent.resources.limits.cpu"
-    value = "250m"
+    value = "500m"
   }
   set {
     name  = "agents.containers.agent.resources.limits.memory"
-    value = "512Mi"
+    value = var.datadog_agent_memory_limit
   }
   set {
     name  = "agents.containers.agent.resources.requests.cpu"
@@ -108,7 +126,7 @@ resource "helm_release" "datadog" {
   }
   set {
     name  = "agents.containers.agent.resources.requests.memory"
-    value = "512Mi"
+    value = var.datadog_agent_memory_request
   }
 
   # process agent memory
@@ -122,11 +140,11 @@ resource "helm_release" "datadog" {
   }
   set {
     name  = "agents.containers.processAgent.resources.requests.cpu"
-    value = "250m"
+    value = "125m"
   }
   set {
     name  = "agents.containers.processAgent.resources.requests.memory"
-    value = "512Mi"
+    value = "256Mi"
   }
 
   # trace agent memory
@@ -140,11 +158,11 @@ resource "helm_release" "datadog" {
   }
   set {
     name  = "agents.containers.traceAgent.resources.requests.cpu"
-    value = "250m"
+    value = "125m"
   }
   set {
     name  = "agents.containers.traceAgent.resources.requests.memory"
-    value = "512Mi"
+    value = "256Mi"
   }
 
 }

--- a/helm.tf
+++ b/helm.tf
@@ -56,3 +56,24 @@ resource "helm_release" "reloader" {
     value = "json"
   }
 }
+
+resource "helm_release" "datadog" {
+  count = var.enable_datadog ? 1 : 0
+
+  name       = "datadog"
+  repository = "https://helm.datadoghq.com"
+  chart      = "datadog"
+
+  namespace = var.existing_namespace ? var.custom_namespace : kubernetes_namespace.dbt_cloud.0.metadata.0.name
+
+  set_sensitive {
+    name  = "datadog.apiKey"
+    value = var.datadog_api_key
+  }
+
+  set {
+    name  = "datadog.apm.enabled"
+    value = var.enable_datadog_apm
+  }
+
+}

--- a/helm.tf
+++ b/helm.tf
@@ -60,7 +60,7 @@ resource "helm_release" "reloader" {
 resource "helm_release" "datadog" {
   count = var.enable_datadog ? 1 : 0
 
-  name       = "datadog"
+  name       = "datadog-agent"
   repository = "https://helm.datadoghq.com"
   chart      = "datadog"
 
@@ -74,6 +74,77 @@ resource "helm_release" "datadog" {
   set {
     name  = "datadog.apm.enabled"
     value = var.enable_datadog_apm
+  }
+
+  set {
+    name  = "datadog.logs.enabled"
+    value = true
+  }
+  set {
+    name  = "datadog.logs.containerCollectAll"
+    value = true
+  }
+  set {
+    name  = "datadog.leaderElection"
+    value = true
+  }
+  set {
+    name  = "datadog.collectEvents"
+    value = true
+  }
+
+  # agent memory
+  set {
+    name  = "agents.containers.agent.resources.limits.cpu"
+    value = "250m"
+  }
+  set {
+    name  = "agents.containers.agent.resources.limits.memory"
+    value = "512Mi"
+  }
+  set {
+    name  = "agents.containers.agent.resources.requests.cpu"
+    value = "250m"
+  }
+  set {
+    name  = "agents.containers.agent.resources.requests.memory"
+    value = "512Mi"
+  }
+
+  # process agent memory
+  set {
+    name  = "agents.containers.processAgent.resources.limits.cpu"
+    value = "250m"
+  }
+  set {
+    name  = "agents.containers.processAgent.resources.limits.memory"
+    value = "512Mi"
+  }
+  set {
+    name  = "agents.containers.processAgent.resources.requests.cpu"
+    value = "250m"
+  }
+  set {
+    name  = "agents.containers.processAgent.resources.requests.memory"
+    value = "512Mi"
+  }
+
+  # trace agent memory
+  set {
+    name  = "agents.containers.traceAgent.resources.limits.cpu"
+    value = "250m"
+  }
+  set {
+    name  = "agents.containers.traceAgent.resources.limits.memory"
+    value = "512Mi"
+  }
+  set {
+    name  = "agents.containers.traceAgent.resources.requests.cpu"
+    value = "250m"
+  }
+  set {
+    name  = "agents.containers.traceAgent.resources.requests.memory"
+    value = "512Mi"
   }
 
 }

--- a/variables.tf
+++ b/variables.tf
@@ -226,7 +226,33 @@ variable "datadog_api_key" {
 variable "enable_datadog_apm" {
   type        = bool
   default     = false
-  description = "Set to `true` to enable APM for Datadog. Will only take effect if `enable_datadog_agent` is also set to `true`."
+  description = "Set to `true` to enable APM (tracer agent) for Datadog. Will only take effect if `enable_datadog_agent` is also set to `true`."
+}
+variable "enable_datadog_cluster_agent" {
+  type        = bool
+  default     = false
+  description = "Set to `true` to enable cluster agent for Datadog. Will only take effect if `enable_datadog_agent` is also set to `true`."
+}
+variable "enable_datadog_kube_state_metrics" {
+  type        = bool
+  default     = false
+  description = "Set to `true` to enable kube state metrics for Datadog. Will only take effect if `enable_datadog_agent` is also set to `true`."
+}
+variable "enable_datadog_process_agent" {
+  type        = bool
+  default     = false
+  description = "Set to `true` to enable process agent for Datadog. Will only take effect if `enable_datadog_agent` is also set to `true`."
+}
+variable "datadog_agent_memory_request" {
+  type        = string
+  default     = "256Mi"
+  description = "The resource memory request of the Datadog agent."
+}
+
+variable "datadog_agent_memory_limit" {
+  type        = string
+  default     = "512Mi"
+  description = "The resource memory limit of the Datadog agent."
 }
 
 # locals

--- a/variables.tf
+++ b/variables.tf
@@ -221,7 +221,7 @@ variable "enable_reloader" {
 variable "datadog_api_key" {
   type        = string
   default     = ""
-  description = "Must be set if `enable_datadog` is set to `true`"
+  description = "If `enable_datadog` is set to `true`, this variable must be set to valid API key of the destination Datadog account."
 }
 variable "enable_datadog_apm" {
   type        = bool

--- a/variables.tf
+++ b/variables.tf
@@ -108,7 +108,7 @@ variable "superuser_password" {
   default     = "<ENTER_SUPER_USER_PASSWORD>"
   description = "Admin Console Script - The superuser password for the dbt Cloud application. This is added to the config that is automatically uploaded to the KOTS admin console via the script."
 }
-variable "datadog_enabled" {
+variable "enable_datadog" {
   type        = bool
   default     = false
   description = "If set to `true` this will enable dbt Cloud to send metrics to Datadog. Note that this requires the installation of a Datadog Agent in the K8s cluster where dbt Cloud is deployed."
@@ -217,6 +217,16 @@ variable "enable_reloader" {
   type        = bool
   default     = true
   description = "Set to `false` to disable reloader."
+}
+variable "datadog_api_key" {
+  type        = string
+  default     = ""
+  description = "Must be set if `enable_datadog` is set to `true`"
+}
+variable "enable_datadog_apm" {
+  type        = bool
+  default     = false
+  description = "Set to `true` to enable APM for Datadog. Will only take effect if `enable_datadog_agent` is also set to `true`."
 }
 
 # locals


### PR DESCRIPTION
This PR adds a helm chart resource to deploy the datadog agent with options to enable APM (tracer agent), cluster agent, kube state metrics, and the process agent. This has been tested in multiple single tenant instances.

```
------------------------------------------------------------------------

An execution plan has been generated and is shown below.
Resource actions are indicated with the following symbols:
  + create
-/+ destroy and then create replacement

Terraform will perform the following actions:

  # module.single_tenant_staging.helm_release.datadog[0] will be created
  + resource "helm_release" "datadog" {
      + atomic                     = false
      + chart                      = "datadog"
      + cleanup_on_fail            = false
      + create_namespace           = false
      + dependency_update          = false
      + disable_crd_hooks          = false
      + disable_openapi_validation = false
      + disable_webhooks           = false
      + force_update               = false
      + id                         = (known after apply)
      + lint                       = false
      + max_history                = 0
      + metadata                   = (known after apply)
      + name                       = "datadog-agent"
      + namespace                  = "dbt-cloud-singletenant-test"
      + recreate_pods              = false
      + render_subchart_notes      = true
      + replace                    = false
      + repository                 = "https://helm.datadoghq.com"
      + reset_values               = false
      + reuse_values               = false
      + skip_crds                  = false
      + status                     = "deployed"
      + timeout                    = 300
      + verify                     = false
      + version                    = "2.8.5"
      + wait                       = true

      + set {
          + name  = "agents.containers.agent.resources.limits.cpu"
          + value = "500m"
        }
      + set {
          + name  = "agents.containers.agent.resources.limits.memory"
          + value = "512Mi"
        }
      + set {
          + name  = "agents.containers.agent.resources.requests.cpu"
          + value = "250m"
        }
      + set {
          + name  = "agents.containers.agent.resources.requests.memory"
          + value = "256Mi"
        }
      + set {
          + name  = "agents.containers.processAgent.resources.limits.cpu"
          + value = "250m"
        }
      + set {
          + name  = "agents.containers.processAgent.resources.limits.memory"
          + value = "512Mi"
        }
      + set {
          + name  = "agents.containers.processAgent.resources.requests.cpu"
          + value = "125m"
        }
      + set {
          + name  = "agents.containers.processAgent.resources.requests.memory"
          + value = "256Mi"
        }
      + set {
          + name  = "agents.containers.traceAgent.resources.limits.cpu"
          + value = "250m"
        }
      + set {
          + name  = "agents.containers.traceAgent.resources.limits.memory"
          + value = "512Mi"
        }
      + set {
          + name  = "agents.containers.traceAgent.resources.requests.cpu"
          + value = "125m"
        }
      + set {
          + name  = "agents.containers.traceAgent.resources.requests.memory"
          + value = "256Mi"
        }
      + set {
          + name  = "clusterAgent.enabled"
          + value = "false"
        }
      + set {
          + name  = "datadog.apm.enabled"
          + value = "true"
        }
      + set {
          + name  = "datadog.collectEvents"
          + value = "true"
        }
      + set {
          + name  = "datadog.dogstatsd.useHostPort"
          + value = "true"
        }
      + set {
          + name  = "datadog.kubeStateMetricsEnabled"
          + value = "false"
        }
      + set {
          + name  = "datadog.leaderElection"
          + value = "true"
        }
      + set {
          + name  = "datadog.logs.containerCollectAll"
          + value = "true"
        }
      + set {
          + name  = "datadog.logs.enabled"
          + value = "true"
        }
      + set {
          + name  = "datadog.processAgent.enabled"
          + value = "false"
        }

      + set_sensitive {
          + name  = "datadog.apiKey"
          + value = (sensitive value)
        }
    }

Plan: 1 to add, 0 to change, 0 to destroy.

------------------------------------------------------------------------
```